### PR TITLE
fix template stages to build with ghc 922

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -49,8 +49,6 @@ instance Hashable (Some Key) where
       IntKey i -> hashWithSalt salt (0 :: Int, i)
       StringKey s -> hashWithSalt salt (1 :: Int, s)
 
-deriveArgDict ''Key
-
 instance GEq Key where
   geq (IntKey i1) (IntKey i2)
     | i1 == i2 =
@@ -80,6 +78,8 @@ instance GCompare Key where
       GLT
     | otherwise =
       GGT
+
+deriveArgDict ''Key
 
 int :: Gen Int
 int = Gen.int (Range.linear 0 100)


### PR DESCRIPTION
This was failing with the following error:
```sh
Building library for rock-0.3.1.1..
[1 of 3] Compiling Rock.Traces      ( src/Rock/Traces.hs, dist/build/Rock/Traces.o, dist/build/Rock/Traces>
[2 of 3] Compiling Rock.Core        ( src/Rock/Core.hs, dist/build/Rock/Core.o, dist/build/Rock/Core.dyn_o>
[3 of 3] Compiling Rock             ( src/Rock.hs, dist/build/Rock.o, dist/build/Rock.dyn_o )
[1 of 3] Compiling Rock.Traces      ( src/Rock/Traces.hs, dist/build/Rock/Traces.p_o )
[2 of 3] Compiling Rock.Core        ( src/Rock/Core.hs, dist/build/Rock/Core.p_o )
[3 of 3] Compiling Rock             ( src/Rock.hs, dist/build/Rock.p_o )
Preprocessing test suite 'test-rock' for rock-0.3.1.1..
Building test suite 'test-rock' for rock-0.3.1.1..
[1 of 1] Compiling Main             ( tests/Main.hs, dist/build/test-rock/test-rock-tmp/Main.o, dist/build>

tests/Main.hs:46:10: error:
    • No instance for (GEq Key)
        arising from the superclasses of an instance declaration
    • In the instance declaration for ‘Hashable (Some Key)’
   |
46 | instance Hashable (Some Key) where
   |          ^^^^^^^^^^^^^^^^^^^
```