### PR TITLE
Added github actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: Rock CI
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ghc-version: ["9.4.4", "9.6.2"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: "latest"
+          cabal-update: true
+
+      - name: Installed minor versions of GHC and Cabal
+        shell: bash
+        run: |
+          GHC_VERSION=$(ghc --numeric-version)
+          CABAL_VERSION=$(cabal --numeric-version)
+          echo "GHC_VERSION=${GHC_VERSION}"     >> "${GITHUB_ENV}"
+          echo "CABAL_VERSION=${CABAL_VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests
+          cabal build --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: |
+            ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-
+
+      - name: Install dependencies
+        run: |
+          cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # Caches are immutable, trying to save with the same key would error.
+        if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: |
+          cabal build all
+
+      - name: Run tests
+        run: |
+          cabal test all

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![CI Build Status](https://github.com/ollef/rock/actions/workflows/ci.yml/badge.svg?branch=ci)](https://github.com/ollef/rock/actions/workflows/ci.yml)
+# rock 
+[![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) 
+[![CI Status](https://github.com/ollef/rock/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ollef/rock/actions/workflows/ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/rock.svg)](https://hackage.haskell.org/package/rock)
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![CI Build Status](https://github.com/ollef/rock/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ollef/rock/actions/workflows/ci.yml)
+# rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![CI Build Status](https://github.com/ollef/rock/actions/workflows/ci.yml/badge.svg?branch=ci)](https://github.com/ollef/rock/actions/workflows/ci.yml)
 [![Hackage](https://img.shields.io/hackage/v/rock.svg)](https://hackage.haskell.org/package/rock)
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![Hackage](https://img.shields.io/hackage/v/rock.svg)](https://hackage.haskell.org/package/rock)
 
+[![CI Build Status](https://github.com/placidex/rock/actions/workflows/ci.yml/badge.svg?branch=ci)](https://github.com/placidex/rock/actions/workflows/ci.yml)
+
+
 A build system inspired by [Build systems à la carte](https://www.microsoft.com/en-us/research/publication/build-systems-la-carte/).
 
 Used in [Sixten](https://github.com/ollef/sixten),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![Hackage](https://img.shields.io/hackage/v/rock.svg)](https://hackage.haskell.org/package/rock)
+# rock [![Build Status](https://travis-ci.com/ollef/rock.svg?branch=master)](https://travis-ci.com/ollef/rock) [![CI Build Status](https://github.com/ollef/rock/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/ollef/rock/actions/workflows/ci.yml)
+[![Hackage](https://img.shields.io/hackage/v/rock.svg)](https://hackage.haskell.org/package/rock)
 
-[![CI Build Status](https://github.com/placidex/rock/actions/workflows/ci.yml/badge.svg?branch=ci)](https://github.com/placidex/rock/actions/workflows/ci.yml)
 
 
 A build system inspired by [Build systems à la carte](https://www.microsoft.com/en-us/research/publication/build-systems-la-carte/).


### PR DESCRIPTION
- CI build with GHC versions 9.4 and 9.6 on Ubuntu and MacOS
- Status badge for github CI workflow in `README.md`