### PR TITLE
Prepare for release `0.3.1.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+# 0.3.1.2
+
+- Add docs about query params, mention Eclair in README
+- Add note about IO actions
+- Fix template stages to build with GHC 9.2.2
+- Fix build errors with GHC 9.6.2
+- Add CI in GitHub Actions Workflow
+
 # 0.3.1.1
 
 - Fix a concurrency bug in `memoiseWithCycleDetection`, where a race condition meant that it could sometimes throw a `Cyclic` exception when there weren't actually cycles

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Olle Fredriksson (c) 2018-2021
+Copyright Olle Fredriksson (c) 2018-2023
 
 All rights reserved.
 

--- a/rock.cabal
+++ b/rock.cabal
@@ -1,5 +1,5 @@
 name:                rock
-version:             0.3.1.1
+version:             0.3.1.2
 synopsis:            A build system for incremental, parallel, and demand-driven computations
 description:         See <https://www.github.com/ollef/rock> for more
                      information and
@@ -10,7 +10,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Olle Fredriksson
 maintainer:          fredriksson.olle@gmail.com
-copyright:           2018-2021 Olle Fredriksson
+copyright:           2018-2023 Olle Fredriksson
 category:            Development
 build-type:          Simple
 extra-source-files:
@@ -21,6 +21,9 @@ tested-with:         GHC == 8.2.2
                    , GHC == 8.4.3
                    , GHC == 8.6.5
                    , GHC == 8.8.3
+                   , GHC == 9.2.2
+                   , GHC == 9.4.4
+                   , GHC == 9.6.2
 
 library
   ghc-options:         -Wall
@@ -39,17 +42,17 @@ library
                        Rock.Core
                        Rock.Traces
   build-depends:       base >= 4.7 && < 5
-                     , constraints-extras >= 0.3
-                     , dependent-hashmap >= 0.1
-                     , dependent-sum >= 0.6
-                     , deriving-compat >= 0.5
-                     , hashable >= 1.3
-                     , lifted-base >= 0.2
-                     , monad-control >= 1.0
-                     , mtl >= 2.2
-                     , transformers >= 0.5
-                     , transformers-base >= 0.4
-                     , unordered-containers >= 0.2
+                     , constraints-extras >= 0.4.0 && < 0.5
+                     , dependent-hashmap >= 0.1.0 && < 0.2
+                     , dependent-sum >= 0.7.2 && < 0.8
+                     , deriving-compat >= 0.6.5 && < 0.7
+                     , hashable >= 1.4.3 && < 1.5
+                     , lifted-base >= 0.2.3 && < 0.3
+                     , monad-control >= 1.0.3 && < 1.1
+                     , mtl >= 2.3.1 && < 2.4
+                     , transformers >= 0.6.1 && < 0.7
+                     , transformers-base >= 0.4.6 && < 0.5
+                     , unordered-containers >= 0.2.19 && < 0.3
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
 


### PR DESCRIPTION
- Bump up version
- Add version bounds suggested by `cabal gen-bounds`
- Update Copyright year upper bound