### PR TITLE
fix: relax `hashable` constraint upper bound

### DIFF
--- a/rock.cabal
+++ b/rock.cabal
@@ -46,7 +46,7 @@ library
                      , dependent-hashmap >= 0.1.0 && < 0.2
                      , dependent-sum >= 0.7.2 && < 0.8
                      , deriving-compat >= 0.6.5 && < 0.7
-                     , hashable >= 1.4.3 && < 1.5
+                     , hashable >= 1.4.3
                      , lifted-base >= 0.2.3 && < 0.3
                      , monad-control >= 1.0.3 && < 1.1
                      , mtl >= 2.3.1 && < 2.4


### PR DESCRIPTION
Building `rock` with GHC 9.12.2 fails due to two issues:

1. `foldl'` ambiguity in `dependent-hashmap`, which should be fixed by this PR: https://github.com/ollef/dependent-hashmap/pull/4

2. Overly strict `hashable` upper bound.

The package `dependent-hashmap-0.1.0.1` allows `hashable >= 1.3`, so Cabal selects `1.5.0.0`. Since `rock-0.3.1.2` limits `hashable < 1.5`, the solver backtracks to `rock-0.3.1.1`, which then fails due to the missing `MonadFix` (which is not a problem in 0.3.1.2).